### PR TITLE
Upcoming breaking changes in `loo_compare()` output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
 # BayesERtools 0.2.5 (in development)
 
 ## Major changes
-  
+
+* Updated compatibility with upcoming changes to `loo_compare()` output
+  structure in the `loo` package (> 2.9.0), which now returns a data frame
+  instead of a matrix and includes additional diagnostic columns.
+
 ## Minor changes
 
 * Allow manual breaks in `plot_er()` to control the position of the probability

--- a/R/dev_ermod_lin.R
+++ b/R/dev_ermod_lin.R
@@ -489,7 +489,11 @@ dev_ermod_lin_cov_sel <- function(
       function(.x) loo(.x)
     )
     comp_exposures <- loo::loo_compare(l_loo_exposures)
-    var_exposure <- rownames(comp_exposures)[[1]]
+    if ("model" %in% colnames(comp_exposures)) {
+      var_exposure <- comp_exposures$model[[1]]
+    } else {
+      var_exposure <- rownames(comp_exposures)[[1]]
+    }
 
     if (verbosity_level >= 1) {
       cli::cli_alert_info("The exposure metric selected was: {var_exposure}")

--- a/tests/testthat/test-dev_ermod_lin.R
+++ b/tests/testthat/test-dev_ermod_lin.R
@@ -209,10 +209,17 @@ mod_mtcars <- dev_ermod_bin(
 
 test_that("Exposure metrics selection", {
   expect_equal(extract_var_exposure(ermod_bin_exp_sel), "AUCss_1000")
-  expect_equal(
-    extract_exp_sel_comp(ermod_bin_exp_sel)[, 1],
-    c(AUCss_1000 = 0.000000, Cmaxss = -0.6490312, Cminss = -2.7563957)
-  )
+  if ("model" %in% colnames(extract_exp_sel_comp(ermod_bin_exp_sel))) {
+    expect_equal(
+      extract_exp_sel_comp(ermod_bin_exp_sel)[, 2],
+      c(0.000000, -0.6490312, -2.7563957)
+    )
+  } else {
+    expect_equal(
+      extract_exp_sel_comp(ermod_bin_exp_sel)[, 1],
+      c(AUCss_1000 = 0.000000, Cmaxss = -0.6490312, Cminss = -2.7563957)
+    )
+  }
 
   priors <- prior_summary(ermod_bin_exp_sel$l_mod_exposures[[2]])
   expect_equal(priors$prior$scale, 5)

--- a/tests/testthat/test-loo_kfold.R
+++ b/tests/testthat/test-loo_kfold.R
@@ -104,7 +104,11 @@ if (.if_run_ex_eval_mod()) {
   })
 
   test_that("kfold", {
-    expect_gt(comp[[2, 1]], -0.5)
+    if ("model" %in% colnames(comp)) {
+      expect_gt(comp[[2, 2]], -0.5)
+    } else {
+      expect_gt(comp[[2, 1]], -0.5)
+    }
     expect_equal(
       kfold_ermod_bin$estimates[, 1],
       c(elpd_kfold = -38.242947, p_kfold = 3.040264, kfoldic = 76.485893)


### PR DESCRIPTION
## Description
In the `loo` package, we are making changes to the output structure returned by `loo_compare()` in [PR #300](https://github.com/stan-dev/loo/pull/300). The main changes are a transition from a matrix to a data frame and the addition of several new columns. Here is an example of the updated output structure:

```
> loo_compare(w1, w2)
  model elpd_diff se_diff p_worse diag_diff diag_elpd
 model1       0.0     0.0      NA                    
 model2      -4.1     0.1    1.00   N < 100     
     
Diagnostic flags present.
See ?`loo-glossary` (sections `diag_diff` and `diag_elpd`)
or https://mc-stan.org/loo/reference/loo-glossary.html.
```

More context on the motivation behind these changes can be found in the updated case study ["Uncertainty in Bayesian LOO-CV Model Comparison"](https://users.aalto.fi/~ave/casestudies/LOO_uncertainty/loo_uncertainty.html).

A **reverse dependency check revealed that these changes will affect your package**. To help smooth the transition, I have already reviewed your code and suggest within this PR changes that should keep your package compatible with both the current and the upcoming `loo_compare()` output structure.

I may have missed some additional spots in your code that need updating, so please feel free to point those out and I am happy to help. Thank you and please do not hesitate to reach out if you have any questions or concerns.